### PR TITLE
Fix non-functionality on Windows.

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,5 +194,7 @@ func canonicalName(anyName string) string {
 	} else {
 		return anyName
 	}
+	panic("unreachable")
+}
 
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -188,5 +189,10 @@ func binaries(filter map[string]matched) ([]string, error) {
 // canonicalName converts a filename which may have a ".exe" extension to the
 // equivalent filename with no ".exe" extension.
 func canonicalName(anyName string) string {
-	return strings.TrimSuffix(anyName, ".exe")
+	if "windows" == runtime.GOOS {
+		return strings.TrimSuffix(anyName, ".exe")
+	} else {
+		return anyName
+	}
+
 }

--- a/main.go
+++ b/main.go
@@ -176,6 +176,10 @@ func binaries(filter map[string]matched) ([]string, error) {
 				if _, ok := filter[canonicalName(fi.Name())]; !ok {
 					continue
 				}
+				// Ignore non-exe files on Windows.
+				if fi.Name() != binaryName(canonicalName(fi.Name())) {
+					continue
+				}
 				filter[canonicalName(fi.Name())] = matched(true)
 			}
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	filter := make(map[string]matched)
 	if args := flag.Args(); len(args) != 0 {
 		for _, arg := range args {
-			filter[canonicalName(arg)] = matched(false)
+			filter[arg] = matched(false)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -186,8 +186,8 @@ func binaries(filter map[string]matched) ([]string, error) {
 	return binaries, nil
 }
 
-// canonicalName converts a filename which may have a ".exe" extension to the
-// equivalent filename with no ".exe" extension.
+// canonicalName, when called on a Windows system, trims the ".exe" suffix from
+// the end of a binary's filename.
 func canonicalName(anyName string) string {
 	if "windows" == runtime.GOOS {
 		return strings.TrimSuffix(anyName, ".exe")

--- a/main.go
+++ b/main.go
@@ -198,7 +198,6 @@ func canonicalName(anyName string) string {
 	} else {
 		return anyName
 	}
-	panic("unreachable")
 }
 
 // binaryName, when called on a Windows system, adds a ".exe" suffix to a
@@ -209,5 +208,4 @@ func binaryName(canonicalName string) string {
 	} else {
 		return canonicalName
 	}
-	panic("unreachable")
 }

--- a/main.go
+++ b/main.go
@@ -170,14 +170,14 @@ func binaries(filter map[string]matched) ([]string, error) {
 			if strings.HasPrefix(fi.Name(), ".") {
 				continue
 			}
+			// Ignore non-exe files on Windows.
+			if fi.Name() != binaryName(canonicalName(fi.Name())) {
+				continue
+			}
 
 			// If user specified a list of binaries, filter out binaries that don't match.
 			if len(filter) != 0 {
 				if _, ok := filter[canonicalName(fi.Name())]; !ok {
-					continue
-				}
-				// Ignore non-exe files on Windows.
-				if fi.Name() != binaryName(canonicalName(fi.Name())) {
 					continue
 				}
 				filter[canonicalName(fi.Name())] = matched(true)

--- a/main.go
+++ b/main.go
@@ -197,4 +197,13 @@ func canonicalName(anyName string) string {
 	panic("unreachable")
 }
 
+// binaryName, when called on a Windows system, adds a ".exe" suffix to a
+// basename to produce the name of a binary in the Windows filesystem.
+func binaryName(canonicalName string) string {
+	if "windows" == runtime.GOOS {
+		return canonicalName + ".exe"
+	} else {
+		return canonicalName
+	}
+	panic("unreachable")
 }

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	filter := make(map[string]matched)
 	if args := flag.Args(); len(args) != 0 {
 		for _, arg := range args {
-			filter[arg] = matched(false)
+			filter[canonicalName(arg)] = matched(false)
 		}
 	}
 
@@ -172,15 +172,21 @@ func binaries(filter map[string]matched) ([]string, error) {
 
 			// If user specified a list of binaries, filter out binaries that don't match.
 			if len(filter) != 0 {
-				if _, ok := filter[fi.Name()]; !ok {
+				if _, ok := filter[canonicalName(fi.Name())]; !ok {
 					continue
 				}
-				filter[fi.Name()] = matched(true)
+				filter[canonicalName(fi.Name())] = matched(true)
 			}
 
-			binaries = append(binaries, fi.Name())
+			binaries = append(binaries, canonicalName(fi.Name()))
 		}
 	}
 
 	return binaries, nil
+}
+
+// canonicalName converts a filename which may have a ".exe" extension to the
+// equivalent filename with no ".exe" extension.
+func canonicalName(anyName string) string {
+	return strings.TrimSuffix(anyName, ".exe")
 }

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "cannot find binary %q in any of:\n", binary)
 		workspaces := filepath.SplitList(build.Default.GOPATH)
 		for i, workspace := range workspaces {
-			path := filepath.Join(workspace, "bin", binary)
+			path := filepath.Join(workspace, "bin", binaryName(binary))
 			switch i {
 			case 0:
 				fmt.Fprintf(os.Stderr, "\t%s (from $GOPATH)\n", path)


### PR DESCRIPTION
Because of the .exe extension of Go-produced binaries on Windows,
binstale could not tell that those binaries came from similarly-named Go
packages (The go command used to get the names of installed packages
returns a directory name, which obviously will not contain .exe).

To fix this, we normalize the names of packages as they come in via
arguments and file system queries. This normalization occurs before the
printing of executable names, but can be moved to after if users would
prefer to see the file extension (I prefer not to, as there is a clearer
mapping between binary and package this way.).

Arguments to binstale can now be in the form "binary" or "binary.exe";
Both formats end up producing identical output. This detail creates some
strange but hopefully meaningless edge cases, however. "binstale .exe"
will display a message telling the user that binary "" cannot be
found. If two packages exist on the system, one named
"github.com/example/binstale" and one named
"github.com/example/binstale.exe", both "binstale binstale" and
"binstale binstale.exe" will check the former binary's staleness, while
only "binstale binstale.exe.exe" will check the latter's.
