### PR TITLE
Display stale reason for stale binaries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - 1.6
+  - 1.7
   - tip
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# binstale [![Build Status](https://travis-ci.org/shurcooL/binstale.svg?branch=master)](https://travis-ci.org/shurcooL/binstale) [![GoDoc](https://godoc.org/github.com/shurcooL/binstale?status.svg)](https://godoc.org/github.com/shurcooL/binstale)
+binstale
+========
+
+[![Build Status](https://travis-ci.org/shurcooL/binstale.svg?branch=master)](https://travis-ci.org/shurcooL/binstale) [![GoDoc](https://godoc.org/github.com/shurcooL/binstale?status.svg)](https://godoc.org/github.com/shurcooL/binstale)
 
 binstale tells you whether the binaries in your GOPATH/bin are stale or up to date.
 
@@ -11,80 +14,83 @@ This is an example of binstale usage.
 
 	$ binstale goimports
 	goimports
-		STALE: golang.org/x/tools/cmd/goimports
+		STALE: golang.org/x/tools/cmd/goimports (newer dependency)
 	$ go install golang.org/x/tools/cmd/goimports
 	$ binstale goimports
 	goimports
 		up to date: golang.org/x/tools/cmd/goimports
+
 	$ binstale
 	Go-Package-Store
-		STALE: github.com/shurcooL/Go-Package-Store
+		STALE: github.com/shurcooL/Go-Package-Store (newer source file)
 	binstale
 		up to date: github.com/shurcooL/binstale
 	doc
 		(no source package found)
 	dump_args
-		STALE: github.com/shurcooL/cmd/dump_args
-	dump_glfw3_joysticks
-		STALE: github.com/shurcooL/cmd/dump_glfw3_joysticks
+		STALE: github.com/shurcooL/cmd/dump_args (build ID mismatch)
 	dump_httpreq
-		STALE: github.com/shurcooL/cmd/dump_httpreq
+		STALE: github.com/shurcooL/cmd/dump_httpreq (build ID mismatch)
 	dupl
-		STALE: github.com/mibk/dupl
-	gencomponent
-		STALE: github.com/neelance/dom/gencomponent
+		STALE: github.com/mibk/dupl (build ID mismatch)
 	git-branches
-		STALE: github.com/shurcooL/cmd/git-branches
+		STALE: github.com/shurcooL/cmd/git-branches (build ID mismatch)
 	git-codereview
-		STALE: golang.org/x/review/git-codereview
-	go-bindata
-		STALE: github.com/jteeuwen/go-bindata/go-bindata
+		STALE: golang.org/x/review/git-codereview (build ID mismatch)
 	go-find-references
-		STALE: github.com/lukehoban/go-find-references
+		STALE: github.com/lukehoban/go-find-references (build ID mismatch)
 	go-outline
 		up to date: github.com/lukehoban/go-outline
 	gocode
 		up to date: github.com/nsf/gocode
 	godef
-		STALE: github.com/rogpeppe/godef
+		STALE: github.com/rogpeppe/godef (build ID mismatch)
 	godep
-		STALE: github.com/tools/godep
+		STALE: github.com/tools/godep (build ID mismatch)
 	goexec
-		STALE: github.com/shurcooL/goexec
+		STALE: github.com/shurcooL/goexec (build ID mismatch)
 	goimporters
-		STALE: github.com/shurcooL/cmd/goimporters
+		STALE: github.com/shurcooL/cmd/goimporters (build ID mismatch)
 	goimportgraph
-		STALE: github.com/shurcooL/cmd/goimportgraph
+		STALE: github.com/shurcooL/cmd/goimportgraph (build ID mismatch)
 	goimports
 		up to date: golang.org/x/tools/cmd/goimports
 	golint
-		STALE: github.com/golang/lint/golint
+		STALE: github.com/golang/lint/golint (build ID mismatch)
 	gomobile
-		STALE: golang.org/x/mobile/cmd/gomobile
+		STALE: golang.org/x/mobile/cmd/gomobile (build ID mismatch)
 	gomvpkg
-		STALE: golang.org/x/tools/cmd/gomvpkg
+		STALE: golang.org/x/tools/cmd/gomvpkg (build ID mismatch)
 	gopherjs
-		STALE: github.com/gopherjs/gopherjs
+		STALE: github.com/gopherjs/gopherjs (build ID mismatch)
 	gorename
-		STALE: golang.org/x/tools/cmd/gorename
+		STALE: golang.org/x/tools/cmd/gorename (build ID mismatch)
 	gorepogen
-		STALE: github.com/shurcooL/cmd/gorepogen
+		STALE: github.com/shurcooL/cmd/gorepogen (build ID mismatch)
 	gostatus
-		STALE: github.com/shurcooL/gostatus
+		STALE: github.com/shurcooL/gostatus (build ID mismatch)
 	gostringer
-		STALE: github.com/sourcegraph/gostringer
+		STALE: github.com/sourcegraph/gostringer (build ID mismatch)
 	govers
-		STALE: github.com/rogpeppe/govers
+		STALE: github.com/rogpeppe/govers (cannot stat install target)
 	gtdo
-		STALE: github.com/shurcooL/gtdo
+		STALE: github.com/shurcooL/gtdo (build ID mismatch)
 	implements
 		up to date: honnef.co/go/implements
 	jsonfmt
 		up to date: github.com/shurcooL/cmd/jsonfmt
 	markdownfmt
-		STALE: github.com/shurcooL/markdownfmt
-	rune_stats
-		STALE: github.com/shurcooL/cmd/rune_stats
+		up to date: github.com/shurcooL/markdownfmt
+	staticcheck
+		STALE: honnef.co/go/staticcheck/cmd/staticcheck (build ID mismatch)
+	stringer
+		STALE: golang.org/x/tools/cmd/stringer (build ID mismatch)
+	unconvert
+		up to date: github.com/mdempsky/unconvert
+	unused
+		STALE: honnef.co/go/unused/cmd/unused (build ID mismatch)
+	vfsgendev
+		up to date: github.com/shurcooL/vfsgen/cmd/vfsgendev
 
 Installation
 ------------

--- a/doc.go
+++ b/doc.go
@@ -10,79 +10,82 @@ This is an example of binstale usage.
 
 	$ binstale goimports
 	goimports
-		STALE: golang.org/x/tools/cmd/goimports
+		STALE: golang.org/x/tools/cmd/goimports (newer dependency)
 	$ go install golang.org/x/tools/cmd/goimports
 	$ binstale goimports
 	goimports
 		up to date: golang.org/x/tools/cmd/goimports
+
 	$ binstale
 	Go-Package-Store
-		STALE: github.com/shurcooL/Go-Package-Store
+		STALE: github.com/shurcooL/Go-Package-Store (newer source file)
 	binstale
 		up to date: github.com/shurcooL/binstale
 	doc
 		(no source package found)
 	dump_args
-		STALE: github.com/shurcooL/cmd/dump_args
-	dump_glfw3_joysticks
-		STALE: github.com/shurcooL/cmd/dump_glfw3_joysticks
+		STALE: github.com/shurcooL/cmd/dump_args (build ID mismatch)
 	dump_httpreq
-		STALE: github.com/shurcooL/cmd/dump_httpreq
+		STALE: github.com/shurcooL/cmd/dump_httpreq (build ID mismatch)
 	dupl
-		STALE: github.com/mibk/dupl
-	gencomponent
-		STALE: github.com/neelance/dom/gencomponent
+		STALE: github.com/mibk/dupl (build ID mismatch)
 	git-branches
-		STALE: github.com/shurcooL/cmd/git-branches
+		STALE: github.com/shurcooL/cmd/git-branches (build ID mismatch)
 	git-codereview
-		STALE: golang.org/x/review/git-codereview
-	go-bindata
-		STALE: github.com/jteeuwen/go-bindata/go-bindata
+		STALE: golang.org/x/review/git-codereview (build ID mismatch)
 	go-find-references
-		STALE: github.com/lukehoban/go-find-references
+		STALE: github.com/lukehoban/go-find-references (build ID mismatch)
 	go-outline
 		up to date: github.com/lukehoban/go-outline
 	gocode
 		up to date: github.com/nsf/gocode
 	godef
-		STALE: github.com/rogpeppe/godef
+		STALE: github.com/rogpeppe/godef (build ID mismatch)
 	godep
-		STALE: github.com/tools/godep
+		STALE: github.com/tools/godep (build ID mismatch)
 	goexec
-		STALE: github.com/shurcooL/goexec
+		STALE: github.com/shurcooL/goexec (build ID mismatch)
 	goimporters
-		STALE: github.com/shurcooL/cmd/goimporters
+		STALE: github.com/shurcooL/cmd/goimporters (build ID mismatch)
 	goimportgraph
-		STALE: github.com/shurcooL/cmd/goimportgraph
+		STALE: github.com/shurcooL/cmd/goimportgraph (build ID mismatch)
 	goimports
 		up to date: golang.org/x/tools/cmd/goimports
 	golint
-		STALE: github.com/golang/lint/golint
+		STALE: github.com/golang/lint/golint (build ID mismatch)
 	gomobile
-		STALE: golang.org/x/mobile/cmd/gomobile
+		STALE: golang.org/x/mobile/cmd/gomobile (build ID mismatch)
 	gomvpkg
-		STALE: golang.org/x/tools/cmd/gomvpkg
+		STALE: golang.org/x/tools/cmd/gomvpkg (build ID mismatch)
 	gopherjs
-		STALE: github.com/gopherjs/gopherjs
+		STALE: github.com/gopherjs/gopherjs (build ID mismatch)
 	gorename
-		STALE: golang.org/x/tools/cmd/gorename
+		STALE: golang.org/x/tools/cmd/gorename (build ID mismatch)
 	gorepogen
-		STALE: github.com/shurcooL/cmd/gorepogen
+		STALE: github.com/shurcooL/cmd/gorepogen (build ID mismatch)
 	gostatus
-		STALE: github.com/shurcooL/gostatus
+		STALE: github.com/shurcooL/gostatus (build ID mismatch)
 	gostringer
-		STALE: github.com/sourcegraph/gostringer
+		STALE: github.com/sourcegraph/gostringer (build ID mismatch)
 	govers
-		STALE: github.com/rogpeppe/govers
+		STALE: github.com/rogpeppe/govers (cannot stat install target)
 	gtdo
-		STALE: github.com/shurcooL/gtdo
+		STALE: github.com/shurcooL/gtdo (build ID mismatch)
 	implements
 		up to date: honnef.co/go/implements
 	jsonfmt
 		up to date: github.com/shurcooL/cmd/jsonfmt
 	markdownfmt
-		STALE: github.com/shurcooL/markdownfmt
-	rune_stats
-		STALE: github.com/shurcooL/cmd/rune_stats
+		up to date: github.com/shurcooL/markdownfmt
+	staticcheck
+		STALE: honnef.co/go/staticcheck/cmd/staticcheck (build ID mismatch)
+	stringer
+		STALE: golang.org/x/tools/cmd/stringer (build ID mismatch)
+	unconvert
+		up to date: github.com/mdempsky/unconvert
+	unused
+		STALE: honnef.co/go/unused/cmd/unused (build ID mismatch)
+	vfsgendev
+		up to date: github.com/shurcooL/vfsgen/cmd/vfsgendev
 */
 package main


### PR DESCRIPTION
Go 1.7 adds support to go list command to display the reason a binary is considered stale (i.e., meaning that installing it would have a non-zero effect).

Reference: https://golang.org/doc/go1.7#cmd_go

We can capture and display that reason, when displaying that a binary is stale. This extra information may be helpful in understanding why a binary is considered stale.

Update Travis to Go 1.7.

Update example output in documentation to include stale reason, and regenerate README.

![image](https://cloud.githubusercontent.com/assets/1924134/18428918/85e51512-7885-11e6-8d9a-6306a7a24dde.png)
